### PR TITLE
Revise: only the backend (val cmd_line : unit -> string) is the virtual part

### DIFF
--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -1,0 +1,20 @@
+(*
+ * Copyright (c) 2016 mirage-bootvar AUTHORS
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+val cmd_line : unit -> string
+(** Return the command line passed to the unikernel. This does not include the
+    binary name. *)

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,12 @@
 (library
  (name mirage_bootvar)
  (public_name mirage-bootvar)
- (virtual_modules mirage_bootvar)
- (default_implementation mirage-bootvar.unix))
+ (modules mirage_bootvar)
+ (libraries mirage-bootvar.parse-argv mirage-bootvar.backend))
+
+(library
+ (name backend)
+ (modules backend)
+ (public_name mirage-bootvar.backend)
+ (default_implementation mirage-bootvar.unix)
+ (virtual_modules backend))

--- a/lib/mirage_bootvar.ml
+++ b/lib/mirage_bootvar.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (c) mirage-bootvar AUTHORS
+ * Copyright (c) 2016 mirage-bootvar AUTHORS
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -16,7 +16,6 @@
  *)
 
 let argv () =
-  let cmd_line = Array.fold_left (fun x arg -> x ^ " " ^ arg) "" Sys.argv in
-  match Parse_argv.parse cmd_line with
-  | Ok l -> Array.of_list l
+  match Parse_argv.parse (Backend.cmd_line ()) with
+  | Ok l -> Array.of_list ("mirage" :: l)
   | Error s -> failwith s

--- a/solo5/backend.ml
+++ b/solo5/backend.ml
@@ -14,10 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-external get_cmd_line : unit -> string = "mirage_solo5_get_cmdline"
-
-let argv () =
-  let cmd_line = get_cmd_line () in
-  match Parse_argv.parse cmd_line with
-  | Ok l -> Array.of_list ("mirage" :: l)
-  | Error s -> failwith s
+external cmd_line : unit -> string = "mirage_solo5_get_cmdline"

--- a/solo5/dune
+++ b/solo5/dune
@@ -1,6 +1,6 @@
 (library
  (name mirage_bootvar_solo5)
  (public_name mirage-bootvar.solo5)
- (libraries mirage-bootvar.parse-argv mirage-solo5)
- (implements mirage-bootvar)
+ (libraries mirage-solo5)
+ (implements backend)
  (optional))

--- a/unix/backend.ml
+++ b/unix/backend.ml
@@ -1,0 +1,20 @@
+(*
+ * Copyright (c) mirage-bootvar AUTHORS
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+let cmd_line () =
+  let complete = Array.to_list Sys.argv in
+  match complete with _hd :: tl -> String.concat " " tl | [] -> ""

--- a/unix/dune
+++ b/unix/dune
@@ -1,5 +1,4 @@
 (library
  (name mirage_bootvar_unix)
  (public_name mirage-bootvar.unix)
- (libraries mirage-bootvar.parse-argv)
- (implements mirage-bootvar))
+ (implements backend))

--- a/xen/backend.ml
+++ b/xen/backend.ml
@@ -14,10 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
-external get_cmd_line : unit -> string = "mirage_xen_get_cmdline"
-
-let argv () =
-  let cmd_line = get_cmd_line () in
-  match Parse_argv.parse cmd_line with
-  | Ok l -> Array.of_list ("mirage" :: l)
-  | Error s -> failwith s
+external cmd_line : unit -> string = "mirage_xen_get_cmdline"

--- a/xen/dune
+++ b/xen/dune
@@ -1,6 +1,6 @@
 (library
  (name mirage_bootvar_xen)
  (public_name mirage-bootvar.xen)
- (libraries mirage-bootvar.parse-argv mirage-xen)
- (implements mirage_bootvar)
+ (libraries mirage-xen)
+ (implements backend)
  (optional))


### PR DESCRIPTION
This allows to safe duplication of code :)